### PR TITLE
add io_latency ebpf type

### DIFF
--- a/backend/ebpf/io_latency/io_latency.c
+++ b/backend/ebpf/io_latency/io_latency.c
@@ -1,0 +1,82 @@
+// +build ignore
+
+#include "vmlinux.h"
+
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+char __license[] SEC("license") = "Dual MIT/GPL";
+
+// start track block device requests
+#define DISK_NAME_LEN 16
+#define TASK_COMM_LEN 32
+
+struct blk_req_event {
+    u8 disk_name[DISK_NAME_LEN];
+    u8 comm[TASK_COMM_LEN];
+    u32 cmd_flags;
+    u64 delta_us;
+    u32 pid;
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 10240);
+    __type(key, struct request *);
+    __type(value, u64);
+} blk_req_start_times SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_RINGBUF);
+	__uint(max_entries, 1 << 24);
+} blk_req_events SEC(".maps");
+
+// bpf2go seems to need this for generating the object
+const struct blk_req_event *unused __attribute__((unused));
+
+// start block I/O
+SEC("kprobe/blk_account_io_start")
+int BPF_KPROBE(kprobe__blk_account_io_start, struct request *req)
+{
+    u64 ts = bpf_ktime_get_ns();
+    bpf_map_update_elem(&blk_req_start_times, &req, &ts, 0);
+    return 0;
+}
+
+
+// done block I/O
+SEC("kprobe/blk_account_io_done")
+int BPF_KPROBE(kprobe__blk_account_io_done, struct request *req)
+{
+    u64 *tsp, delta_us;
+    struct blk_req_event *data;
+    tsp = bpf_map_lookup_elem(&blk_req_start_times, &req);
+    if (!tsp) {
+        return 0;   // missed issue
+    }
+    delta_us = (bpf_ktime_get_ns() - *tsp)/1000;
+    bpf_map_delete_elem(&blk_req_start_times, &req);
+
+    if (delta_us < 50) {
+        return 0; // ignore under 50 micro seconds
+    }
+
+    data = bpf_ringbuf_reserve(&blk_req_events, sizeof(struct blk_req_event), 0);
+    if (!data) {
+        return 0; // couldn't reserve
+    }
+
+    data->pid = bpf_get_current_pid_tgid();
+    data->delta_us = delta_us;
+    bpf_core_read(&data->cmd_flags, sizeof(data->cmd_flags), &req->cmd_flags);
+    // NOTE req->rq_disk may be removed in later kernels, this was created on jammy kernel
+    // https://lore.kernel.org/all/20211126121802.2090656-1-hch@lst.de/
+    // https://github.com/iovisor/bcc/issues/3954
+    BPF_CORE_READ_STR_INTO(&data->disk_name, req, rq_disk, disk_name);
+    bpf_get_current_comm(&data->comm, sizeof(data->comm));
+    bpf_ringbuf_submit(data, 0);
+    return 0;
+}
+// end track block device requests
+

--- a/backend/ebpf/io_latency/loader.go
+++ b/backend/ebpf/io_latency/loader.go
@@ -1,0 +1,223 @@
+package ebpf
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"hermes/common"
+	"hermes/log"
+	"io"
+	"os"
+	"time"
+
+	"github.com/cilium/ebpf/link"
+	"github.com/cilium/ebpf/ringbuf"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -type blk_req_event -target $BPF_ARCH -cc $BPF_CLANG -cflags $BPF_CFLAGS bpf io_latency.c -- -I$BPF_VMLINUX_HEADER
+
+const BlkRecFilePostfix = ".blk.rec"
+
+type IoLatLoader struct {
+	objs *bpfObjects
+}
+
+func GetLoader() (*IoLatLoader, error) {
+	// Load pre-compiled programs and maps into the kernel.
+	objs := bpfObjects{}
+	if err := loadBpfObjects(&objs, nil); err != nil {
+		return nil, err
+	}
+
+	return &IoLatLoader{
+		objs: &objs,
+	}, nil
+}
+
+func (loader *IoLatLoader) GetLogDataPathPostfix() string {
+	return BlkRecFilePostfix
+}
+
+func (loader *IoLatLoader) Load(ctx context.Context) error {
+	kpBlkIoStart, err := link.Kprobe("blk_account_io_start", loader.objs.KprobeBlkAccountIoStart, nil)
+	if err != nil {
+		logrus.Errorf("Failed to open blk_account_io_start kprobe, err [%s]", err)
+		return err
+	}
+	defer kpBlkIoStart.Close()
+
+	kpBlkIoDone, err := link.Kprobe("blk_account_io_done", loader.objs.KprobeBlkAccountIoDone, nil)
+	if err != nil {
+		logrus.Errorf("Failed to open blk_account_io_start kprobe, err [%s]", err)
+		return err
+	}
+	defer kpBlkIoDone.Close()
+
+	<-ctx.Done()
+	return nil
+}
+
+// request ops
+// copied from vmlinux.h
+const (
+	REQ_OP_READ  = 0
+	REQ_OP_WRITE = 1
+	REQ_OP_FLUSH = 2
+
+// REQ_OP_DISCARD = 3,
+// REQ_OP_SECURE_ERASE = 5,
+// REQ_OP_WRITE_SAME = 7,
+// REQ_OP_WRITE_ZEROES = 9,
+// REQ_OP_ZONE_OPEN = 10,
+// REQ_OP_ZONE_CLOSE = 11,
+// REQ_OP_ZONE_FINISH = 12,
+// REQ_OP_ZONE_APPEND = 13,
+// REQ_OP_ZONE_RESET = 15,
+// REQ_OP_ZONE_RESET_ALL = 17,
+// REQ_OP_DRV_IN = 34,
+// REQ_OP_DRV_OUT = 35,
+// REQ_OP_LAST = 36,
+// __REQ_FAILFAST_DEV = 8,
+// __REQ_FAILFAST_TRANSPORT = 9,
+// __REQ_FAILFAST_DRIVER = 10,
+)
+
+// request flag bitshifts
+// copied from vmlinux.h
+const (
+	__REQ_SYNC = 11
+
+// __REQ_META = 12,
+// __REQ_PRIO = 13,
+// __REQ_NOMERGE = 14,
+// __REQ_IDLE = 15,
+// __REQ_INTEGRITY = 16,
+// __REQ_FUA = 17,
+// __REQ_PREFLUSH = 18,
+// __REQ_RAHEAD = 19,
+// __REQ_BACKGROUND = 20,
+// __REQ_NOWAIT = 21,
+// __REQ_CGROUP_PUNT = 22,
+// __REQ_NOUNMAP = 23,
+// __REQ_HIPRI = 24,
+// __REQ_DRV = 25,
+// __REQ_SWAP = 26,
+// __REQ_NR_BITS = 27,
+)
+
+const (
+	REQ_SYNC = 1 << __REQ_SYNC
+)
+
+func getOpInfo(b bpfBlkReqEvent) BlkOp {
+	var ret BlkOp
+
+	if b.CmdFlags&REQ_OP_WRITE > 0 {
+		ret.Op = `write`
+	} else if b.CmdFlags&REQ_OP_FLUSH > 0 {
+		ret.Op = `flush`
+	} else if b.CmdFlags&REQ_OP_READ == 0 {
+		ret.Op = `read`
+	} else {
+		ret.Op = `other`
+	}
+
+	if b.CmdFlags&REQ_SYNC > 0 {
+		ret.Sync = true
+	} else {
+		ret.Sync = false
+	}
+
+	return ret
+}
+
+type BlkOp struct {
+	Op   string `json:op`
+	Sync bool   `json:sync`
+}
+
+type BlkLatRec struct {
+	Pid    uint32 `json:pid`
+	LatUs  uint64 `json:lat_us`
+	Device string `json:device`
+	Comm   string `json:comm`
+	OpInfo BlkOp
+}
+
+// Collect records from ringbuff, assumes Load() has already been called
+func (loader *IoLatLoader) getBlkLatRecs() (blkRecs []BlkLatRec) {
+	rd, err := ringbuf.NewReader(loader.objs.BlkReqEvents)
+	rd.SetDeadline(time.Now().Add(1 * time.Second)) // don't wait longer than 1s for samples
+	if err != nil {
+		logrus.Errorf("Failed to open ringbuf reader, err [%s]", err)
+	}
+	defer rd.Close()
+
+	for { // may need to be bounded
+		var blkEvent bpfBlkReqEvent
+		record, err := rd.Read()
+		if err != nil {
+			if err == os.ErrDeadlineExceeded || err == ringbuf.ErrClosed {
+				break
+			}
+		}
+		if err := binary.Read(bytes.NewBuffer(record.RawSample), common.NativeEndian(), &blkEvent); err != nil {
+			if err == io.EOF {
+				break
+			}
+			// there may be some other unchecked error here, we just try reading again
+			continue
+		} else {
+			blkOp := getOpInfo(blkEvent)
+			blkRec := BlkLatRec{
+				Pid:    blkEvent.Pid,
+				LatUs:  blkEvent.DeltaUs,
+				Device: unix.ByteSliceToString(blkEvent.DiskName[:]),
+				Comm:   unix.ByteSliceToString(blkEvent.Comm[:]),
+				OpInfo: blkOp,
+			}
+			blkRecs = append(blkRecs, blkRec)
+		}
+	}
+	return
+}
+
+func (loader *IoLatLoader) writeToFile(outputPath string, bytes *[]byte) error {
+	fp, err := os.OpenFile(outputPath, os.O_WRONLY|os.O_CREATE, 0644)
+	if err != nil {
+		return err
+	}
+	defer fp.Close()
+
+	if _, err = fp.WriteString(string(*bytes)); err != nil {
+		return err
+	}
+	return nil
+}
+func (loader *IoLatLoader) writeBlkRec(outputPath string, recs *[]BlkLatRec) error {
+	bytes, err := json.Marshal(recs)
+	if err != nil {
+		return err
+	}
+
+	return loader.writeToFile(outputPath, &bytes)
+}
+
+func (loader *IoLatLoader) StoreData(logDataPathGenerator log.LogDataPathGenerator) error {
+	blkRecs := loader.getBlkLatRecs()
+	if len(blkRecs) > 0 {
+		if err := loader.writeBlkRec(logDataPathGenerator(BlkRecFilePostfix), &blkRecs); err != nil {
+			logrus.Errorf("Failed to write blk records to file, err [%s]", err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (loader *IoLatLoader) Close() {
+	loader.objs.Close()
+}

--- a/backend/ebpf/loader.go
+++ b/backend/ebpf/loader.go
@@ -7,10 +7,12 @@ import (
 	"hermes/log"
 
 	memory "hermes/backend/ebpf/memory_alloc"
+	iolat "hermes/backend/ebpf/io_latency"
 )
 
 const (
 	MemoryEbpf = "memory"
+	IoLatEbpf = "io_latency"
 )
 
 type Loader interface {
@@ -24,6 +26,8 @@ func GetLoader(ebpfType string) (Loader, error) {
 	switch ebpfType {
 	case MemoryEbpf:
 		return memory.GetLoader()
+	case IoLatEbpf:
+		return iolat.GetLoader()
 	}
 	return nil, fmt.Errorf("Unahndled ebpf type [%s]", ebpfType)
 }

--- a/common/utils.go
+++ b/common/utils.go
@@ -1,11 +1,13 @@
 package common
 
 import (
+	"encoding/binary"
 	"errors"
 	"os"
 	"path/filepath"
 
 	"github.com/joho/godotenv"
+	"golang.org/x/sys/cpu"
 )
 
 const EnvFile = "hermes.env"
@@ -27,4 +29,15 @@ func Contains[T comparable](slices []T, val T) bool {
 		}
 	}
 	return false
+}
+
+func NativeEndian() binary.ByteOrder {
+	endians := map[bool]binary.ByteOrder{}
+	endians[true] = binary.BigEndian
+	endians[false] = binary.LittleEndian
+	return endians[cpu.IsBigEndian]
+
+	// this also works but requires "unsafe" module
+	//var bigEndian = (*(*[2]uint8)(unsafe.Pointer(&[]uint16{1}[0])))[0] == 0
+	//return endians[bigEndian]
 }

--- a/config/io_latency.yaml
+++ b/config/io_latency.yaml
@@ -1,0 +1,10 @@
+class: periodic
+interval: 30
+status: enabled
+routines:
+  io_latency:
+    condition:
+      cpu_info: null
+    content:
+      io_latency: null
+start: io_latency

--- a/config/tasks/io_latency.yaml
+++ b/config/tasks/io_latency.yaml
@@ -1,0 +1,3 @@
+task_type: ebpf
+ebpf_type: io_latency
+timeout: 5

--- a/parser/io_latency_parser.go
+++ b/parser/io_latency_parser.go
@@ -1,0 +1,192 @@
+package parser
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	iolat "hermes/backend/ebpf/io_latency"
+	"hermes/log"
+)
+
+type IoLatParser struct{}
+
+func GetIoLatEbpfParser() (ParserInstance, error) {
+	return &IoLatParser{}, nil
+}
+
+type RawBlkLatRec iolat.BlkLatRec
+
+type BlkLatRecord struct {
+	TotalIos   int    `json:"total_ios"`
+	Reads      int    `json:"reads"`
+	SyncReads  int    `json:"sync_reads"`
+	Writes     int    `json:"writes"`
+	SyncWrites int    `json:"sync_writes"`
+	Other      int    `json:"other"`
+	SyncOther  int    `json:"sync_other"`
+	LatAvgUs   uint64 `json:"lat_avg_us"`
+	LatHighUs  uint64 `json:"lat_high_us"`
+	LatLowUs   uint64 `json:"lat_low_us"`
+	LatSum     uint64 `json:"-"` //only used for calculating average
+}
+
+type PidBlkLatRecord struct {
+	Comm   string       `json:"comm"`
+	BlkLat BlkLatRecord `json:"blk_lat"`
+}
+
+// update BlkLatRecord based on a new raw record
+func (b *BlkLatRecord) update(next RawBlkLatRec) {
+	// update high
+	if next.LatUs > b.LatHighUs || b.TotalIos == 0 {
+		b.LatHighUs = next.LatUs
+	}
+
+	// update low
+	if next.LatUs < b.LatLowUs || b.TotalIos == 0 {
+		b.LatLowUs = next.LatUs
+	}
+
+	// update counts
+	if next.OpInfo.Op == "read" {
+		if next.OpInfo.Sync == true {
+			b.SyncReads += 1
+		} else {
+			b.Reads += 1
+		}
+	}
+
+	if next.OpInfo.Op == "write" {
+		if next.OpInfo.Sync == true {
+			b.SyncWrites += 1
+		} else {
+			b.Writes += 1
+		}
+	}
+
+	if next.OpInfo.Op == "other" {
+		if next.OpInfo.Sync == true {
+			b.SyncOther += 1
+		} else {
+			b.Other += 1
+		}
+	}
+	b.TotalIos += 1
+	b.LatSum += next.LatUs // only used for calculating avg
+}
+
+func (b *BlkLatRecord) calculateAverage() {
+	if b.TotalIos != 0 {
+		b.LatAvgUs = b.LatSum / uint64(b.TotalIos)
+	}
+	return
+}
+
+func (p *IoLatParser) getParsedBlkData(rawRecs []RawBlkLatRec) OutputBlkData {
+	all := BlkLatRecord{}
+	perPid := map[uint32]PidBlkLatRecord{}
+	perDev := map[string]BlkLatRecord{}
+	perComm := map[string]BlkLatRecord{}
+
+	for _, rec := range rawRecs {
+		pid := rec.Pid
+		pidRec := perPid[pid]
+		pidBlkRec := pidRec.BlkLat
+
+		dev := rec.Device
+		devBlkRec := perDev[dev]
+
+		comm := rec.Comm
+		commBlkRec := perComm[comm]
+
+		// set comm for per pid
+		if pidBlkRec.TotalIos == 0 {
+			pidRec.Comm = rec.Comm
+		}
+
+		//update values
+		all.update(rec)
+		pidBlkRec.update(rec)
+		devBlkRec.update(rec)
+		commBlkRec.update(rec)
+
+		// update records
+		pidRec.BlkLat = pidBlkRec
+		perPid[pid] = pidRec
+		perDev[dev] = devBlkRec
+		perComm[comm] = commBlkRec
+
+	}
+
+	// calculate averages
+	all.calculateAverage()
+
+	for i, pidRec := range perPid {
+		pidBlkRec := pidRec.BlkLat
+		pidBlkRec.calculateAverage()
+		pidRec.BlkLat = pidBlkRec
+		perPid[i] = pidRec
+	}
+	for i, devBlkRec := range perDev {
+		devBlkRec.calculateAverage()
+		perDev[i] = devBlkRec
+	}
+	for i, commBlkRec := range perComm {
+		commBlkRec.calculateAverage()
+		perComm[i] = commBlkRec
+	}
+
+	return OutputBlkData{all, perDev, perComm, perPid}
+}
+
+type OutputBlkData struct {
+	AllIo   BlkLatRecord               `json:"all"`
+	PerDev  map[string]BlkLatRecord    `json:"per_dev"`
+	PerComm map[string]BlkLatRecord    `json:"per_comm"`
+	PerPid  map[uint32]PidBlkLatRecord `json:"per_pid"`
+}
+
+// get raw records created by collector
+func (p *IoLatParser) getRawBlkRecord(timestamp int64, path string) ([]RawBlkLatRec, error) {
+	bytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var rawRecords []RawBlkLatRec
+	if err := json.Unmarshal(bytes, &rawRecords); err != nil {
+		return nil, err
+	}
+	return rawRecords, nil
+}
+
+func (p *IoLatParser) writeJSONDataBlk(rec OutputBlkData, path string) error {
+	bytes, err := json.Marshal(&rec)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(path, bytes, 0644)
+}
+
+func (p *IoLatParser) Parse(logDataPathGenerator log.LogDataPathGenerator, timestamp int64, logDataPostfix, outputDir string) error {
+	var rawRecs []RawBlkLatRec
+
+	rawRecs, err := p.getRawBlkRecord(timestamp, logDataPathGenerator(logDataPostfix))
+	if err != nil {
+		return err
+	}
+	outputBlkData := p.getParsedBlkData(rawRecs)
+
+	outputBlkPath := filepath.Join(outputDir, strconv.FormatInt(timestamp, 10), "blk_ios.json")
+	if err := os.MkdirAll(filepath.Dir(outputBlkPath), os.ModePerm); err != nil {
+		return err
+	}
+	err = p.writeJSONDataBlk(outputBlkData, outputBlkPath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -7,11 +7,13 @@ import (
 
 	"hermes/common"
 	"hermes/log"
+	"github.com/sirupsen/logrus"
 )
 
 const (
 	CpuProfileJob     = "cpu_profile"
 	MemleakProfileJob = "memleak_profile"
+	IoLatencyJob      = "io_latency"
 )
 
 type ParserInstance interface {
@@ -44,6 +46,10 @@ func (parser *Parser) getTaskParser(jobName string, taskType common.TaskType) (P
 			common.MemoryInfo: GetMemoryInfoParser,
 			common.Ebpf:       GetMemoryAllocEbpfParser,
 		},
+		IoLatencyJob: {
+			common.CpuInfo: GetCpuInfoParser,
+			common.Ebpf:    GetIoLatEbpfParser,
+		},
 	}
 
 	taskMapping, isExist := parserGetMapping[jobName]
@@ -53,6 +59,7 @@ func (parser *Parser) getTaskParser(jobName string, taskType common.TaskType) (P
 
 	getParser, isExist := taskMapping[taskType]
 	if !isExist {
+		logrus.Printf("parser: %+v", getParser)
 		return nil, fmt.Errorf("Unhandled task type [%d]", taskType)
 	}
 	return getParser()


### PR DESCRIPTION
For collecting data about io latency. This first commit adds block device latency measurement.

The parser outputs an overview of each collected set of IOs data by finding average, high and low values for each collection as well as grouping by dev, by process name (comm) and by pid.