### PR TITLE
Add PSI parser

### DIFF
--- a/config/io_latency.yaml
+++ b/config/io_latency.yaml
@@ -4,7 +4,17 @@ status: enabled
 routines:
   io_latency:
     condition:
-      cpu_info: null
+      psi:
+        type: io
+        thresholds:
+          some:
+            avg10: 50.0
+            avg60: 20.0
+            avg300: 10.0
+          full:
+            avg10: 30.0
+            avg60: 15.0
+            avg300: 5.0
     content:
       io_latency: null
 start: io_latency

--- a/config/tasks/psi.yaml
+++ b/config/tasks/psi.yaml
@@ -1,10 +1,11 @@
 task_type: psi
-type: 0
-some:
-  - -1
-  - -1
-  - -1
-full:
-  - -1
-  - -1
-  - -1
+type: cpu #cpu, io or memory
+thresholds:
+  some:
+    avg10: -1
+    avg60: -1
+    avg300: -1
+  full:
+    avg10: -1
+    avg60: -1
+    avg300: -1

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
 	"hermes/common"
 	"hermes/log"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -47,8 +47,8 @@ func (parser *Parser) getTaskParser(jobName string, taskType common.TaskType) (P
 			common.Ebpf:       GetMemoryAllocEbpfParser,
 		},
 		IoLatencyJob: {
-			common.CpuInfo: GetCpuInfoParser,
-			common.Ebpf:    GetIoLatEbpfParser,
+			common.PSI:  GetPSIParser,
+			common.Ebpf: GetIoLatEbpfParser,
 		},
 	}
 

--- a/parser/psi_parser.go
+++ b/parser/psi_parser.go
@@ -1,0 +1,92 @@
+package parser
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"hermes/backend/utils"
+	"hermes/collector"
+	"hermes/log"
+)
+
+type PSIRecord struct {
+	Timestamp   int64         `json:"timestamp"`
+	Type        utils.PSIType `json:"psi_type"`
+	TriggeredBy string        `json:"triggered_by"`
+	Threshold   float64       `json:"threshold"`
+	Val         float64       `json:"val"`
+	Triggered   bool          `json:"triggered"`
+}
+
+type PSIParser struct{}
+
+func GetPSIParser() (ParserInstance, error) {
+	return &PSIParser{}, nil
+}
+
+func (parser *PSIParser) getPSIRecord(timestamp int64, path string) (*PSIRecord, error) {
+	bytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var context collector.PSIContext
+	if err := json.Unmarshal(bytes, &context); err != nil {
+		return nil, err
+	}
+
+	ret := &PSIRecord{
+		Timestamp:   timestamp,
+		Type:        context.Type,
+		TriggeredBy: context.TriggeredBy,
+		Triggered:   context.Triggered,
+	}
+
+	if context.Triggered {
+		triggerMetric := strings.Split(context.TriggeredBy, "/")[0]
+		triggerInterval := strings.Split(context.TriggeredBy, "/")[1]
+		if triggerMetric == utils.PSISome {
+			ret.Threshold = context.Thresholds.Some.GetInterval(triggerInterval)
+			ret.Val = context.Levels.Some.GetInterval(triggerInterval)
+		} else { // triggerMetric == utils.PSIFull
+			ret.Threshold = context.Thresholds.Full.GetInterval(triggerInterval)
+			ret.Val = context.Levels.Full.GetInterval(triggerInterval)
+		}
+	}
+	return ret, nil
+}
+
+func (parser *PSIParser) writeJSONData(rec *PSIRecord, path string) error {
+	var recs []PSIRecord
+	if _, err := os.Stat(path); err == nil {
+		bytes, err := ioutil.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if err := json.Unmarshal(bytes, &recs); err != nil {
+			return err
+		}
+	}
+
+	recs = append(recs, *rec)
+	bytes, err := json.Marshal(&recs)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(path, bytes, 0644)
+}
+
+func (parser *PSIParser) Parse(logDataPathGenerator log.LogDataPathGenerator, timestamp int64, logDataPostfix, outputDir string) error {
+	rec, err := parser.getPSIRecord(timestamp, logDataPathGenerator(logDataPostfix))
+	if err != nil {
+		return err
+	}
+
+	err = parser.writeJSONData(rec, outputDir+string("/overview"))
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
- modified data types to use strings instead of ints for metric types (cpu,io,memory) and intervals (avg10,avg60,avg300)
- removed use of float arrays for clarity in line with above
- added PSI parser, outputs summaries of PSI records to overview
- added io_psi.yaml example condition file for io_latency job